### PR TITLE
Add turkish translation to tr/profile.json

### DIFF
--- a/tr/profile.json
+++ b/tr/profile.json
@@ -44,9 +44,9 @@
     "popup": "Kiron e-posta hesabını sıfırlaman gerekirse özel e-postana ihtiyacımız olacak. Ek hizmetler için seninle telefon aracılığıyla iletişim kuracağız.",
     "infoMsg": "Kiron, iletişim bilgilerini iznin olmadan kimseyle paylaşmaz.",
     "phone": "Telefon numarası",
-    "can": "iletişim kurabilir",
-    "cannnot": "iletişim kuramaz",
-    "whatsapp": "contact me via WhatsApp Messenger on this number.",
+    "can": "Yes",
+    "cannnot": "No",
+    "whatsapp": "",
     "whatsappCheck": "Kiron, WhatsApp Messenger aracılığıyla benimle iletişim kurabilir.",
     "email": "Özel Eposta",
     "emailMsg": "Yeni bir <1>özel</1> eposta adresin mi var? Burada değiştirebilirsin. Bu adrese bir onay epostası göndereceğiz- <2>lütfen önümüzdeki günlerde onayla</2>."

--- a/tr/profile.json
+++ b/tr/profile.json
@@ -1,71 +1,71 @@
 {
   "header": {
-    "imgSave": "Save",
-    "imgDelete": "Delete",
-    "imgReplace": "Replace",
-    "imgTitle": "Upload your profile picture",
-    "imgInputLabel": "I allow my image to be shown to other Kiron students & staff",
-    "imgUploadMsg": "Upload your profile picture"
+    "imgSave": "Kaydet",
+    "imgDelete": "Sil",
+    "imgReplace": "Değiştir",
+    "imgTitle": "Profil resmi yükle",
+    "imgInputLabel": "Resmimin Kiron öğrencileri ve ekibine gösterilmesine izin veriyorum",
+    "imgUploadMsg": "Profil resmi yükle"
   },
   "editBox": {
-    "cancel": "Cancel",
-    "save": "Save",
-    "edit": "Edit"
+    "cancel": "İptal",
+    "save": "Kaydet",
+    "edit": "Düzenle"
   },
   "languageSwitch": {
-    "title": "Language",
-    "descText": "We are gradually introducing translations for Arabic to Kiron Campus.",
-    "descSubText": "You can change language to Arabic to get a sneak peak."
+    "title": "Dil",
+    "descText": "Türkçeye çevirileri aşama aşama Kiron Kampüs'e sunuyoruz.",
+    "descSubText": "Göz atmak için dili Türkçeye çevirebilirsiniz."
   },
   "personalInfo": {
-    "title": "Personal Information",
-    "popup": "Personal Information is helpful for us to know our students better and provide specific services, e.g. study places for female students",
-    "nickname": "Nickname",
-    "country": "Country of Origin",
-    "countryPlaceholder": "Select a nationality",
-    "birthday": "Date of Birth",
-    "gender": "Gender",
-    "male": "Male",
-    "female": "Female",
-    "other": "Other"
+    "title": "Kişisel bilgiler",
+    "popup": "Kişisel bilgiler, öğrencilerimizi daha iyi tanımak için ve 'kadın öğrenciler için çalışma yerleri' gibi belirli hizmetleri sağlamak için yardımcı olmaktadır",
+    "nickname": "Takma isim",
+    "country": "Ana vatanınız",
+    "countryPlaceholder": "Milletinizi seçin ",
+    "birthday": "Doğum Tarihi ",
+    "gender": "Cinsiyet",
+    "male": "Erkek",
+    "female": "Kadın",
+    "other": "Diğer"
   },
   "location": {
-    "title": "Location",
-    "popup": "Some of our services are only available in certain areas. Knowing your location allows us to send you the right infos.",
-    "infoMsg": "We will not refer any sensitive information to a third party; however, in order to offer tailor-made workshops or events close to you, we need your location details.",
-    "country": "Country",
-    "countryPlaceholder": "Select a country",
-    "city": "City",
-    "none": "None",
-    "btnLabel": "Find other students"
+    "title": "Erkek/ Kadın",
+    "popup": "Bazı hizmetlerimize yalnızca belirli bölgelerde erişilebilir. Konumunu bilmemiz sana doğru bilgileri göndermemizi sağlar.",
+    "infoMsg": "Herhangi bir hassas bilgiyi üçüncü bir kişiye göndermeyeceğiz; ancak, sana en yakın özel atölye çalışmaları veya etkinlikler sunmak için konum bilgilerine ihtiyacımız var.",
+    "country": "Ülke",
+    "countryPlaceholder": "Ülke Seç",
+    "city": "Şehir",
+    "none": "Hiçbiri",
+    "btnLabel": "Diğer öğrencileri bul"
   },
   "contactDetails": {
-    "title": "Contact information",
-    "popup": "We will need your private email if you have to reset your kiron email account. We will contact you via phone for additional services.",
-    "infoMsg": "Kiron does not share your contact details with anybody without your permission.",
-    "phone": "Phone number",
-    "can": "can",
-    "cannnot": "cannot",
+    "title": "İletişim bilgileri",
+    "popup": "Kiron e-posta hesabını sıfırlaman gerekirse özel e-postana ihtiyacımız olacak. Ek hizmetler için seninle telefon aracılığıyla iletişim kuracağız.",
+    "infoMsg": "Kiron, iletişim bilgilerini iznin olmadan kimseyle paylaşmaz.",
+    "phone": "Telefon numarası",
+    "can": "iletişim kurabilir",
+    "cannnot": "iletişim kuramaz",
     "whatsapp": "contact me via WhatsApp Messenger on this number.",
-    "whatsappCheck": "Kiron can contact me via WhatsApp Messenger on this number",
-    "email": "Private email",
-    "emailMsg": "Have a new <1>private</1> email address? You can change it here. We will send you a confirmation email to this address - <2>please confirm</2> it within the next days."
+    "whatsappCheck": "Kiron, WhatsApp Messenger aracılığıyla benimle iletişim kurabilir.",
+    "email": "Özel Eposta",
+    "emailMsg": "Yeni bir <1>özel</1> eposta adresin mi var? Burada değiştirebilirsin. Bu adrese bir onay epostası göndereceğiz- <2>lütfen önümüzdeki günlerde onayla</2>."
   },
   "certificate": {
-    "title": "Certificate of Enrollment",
-    "desc": "Do you need to prove that you are a student with Kiron?",
-    "downloadDesc": "Download your Certificate of Enrollment!",
-    "btnLabel": "Download here",
-    "downloadPlease": "Please",
-    "clickHere": "click here",
-    "downloadLink": "to upload a status document in order to download certificate of enrollment."   
+    "title": "Kayıt Belgesi",
+    "desc": "Kiron ile öğrenci olduğunu kanıtlaman mı gerekiyor?",
+    "downloadDesc": "Kayıt Belgeni indir!",
+    "btnLabel": "Buradan indir",
+    "downloadPlease": "Lütfen",
+    "clickHere": "Buraya tıkla",
+    "downloadLink": "kayıt sertifikasını indirmek amacıyla bir durum belgesi yüklemek için."   
   },
   "COEContainer": {
-    "question": "What are you planning to use your certificate for in the next six months?",
-    "info": "To download the certificate of enrollment, please select one or several uses of the certificate of enrollment above.",
-    "downloadLng": "Download in",
-    "en": "English",
-    "de": "German",
-    "fr": "French"
+    "question": "Önümüzdeki altı ay içinde sertifikanı ne için kullanmayı planlıyorsun?",
+    "info": "Kayıt sertifikasını indirmek için lütfen yukarıdaki kayıt sertifikasının bir veya birkaç kullanımını seç.",
+    "downloadLng": "Şu dilde indir:",
+    "en": "İngilizce",
+    "de": "Almanca",
+    "fr": "Fransızca"
   }
 }


### PR DESCRIPTION
Hello,
There's a code that we would need to change, because of the different structure of phrases in Turkish.
From line 47 to 50= there are the words "can"/"cannot", but there is no such words in Turkish. 
Is it possible to delete those lines (47,48,49), where the sentences in divided in different pieces. And instead, put the whole sentences, like in line 50:
- line 50 is already translated for 'Kiron CAN contact me..."
- new line to create for 'Kiron CANNOT contact me". Turkish version: Kiron, WhatsApp Messenger aracılığıyla benimle iletişim kuramaz.
Thank you